### PR TITLE
feat(transaction-status): add endpoint to retrieve transaction status from Wompi

### DIFF
--- a/Back/payment-onboarding-backend/src/modules/wompi/wompi.controller.ts
+++ b/Back/payment-onboarding-backend/src/modules/wompi/wompi.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Post, Body } from '@nestjs/common';
+import { Controller, Post, Body, Get, Param } from '@nestjs/common';
 import { WompiService } from './wompi.service';
 import { CreateTransactionDto } from './dto/create-transaction.dto';
 
@@ -9,5 +9,10 @@ export class WompiController {
   @Post('transaction') // Ruta completa: POST /wompi/transaction
   async createTransaction(@Body() dto: CreateTransactionDto) {
     return this.wompiService.createTransaction(dto);
+  }
+
+  @Get('transaction-status/:id')
+  async getTransactionStatus(@Param('id') id: string) {
+    return this.wompiService.getTransactionStatus(id);
   }
 }

--- a/Back/payment-onboarding-backend/src/modules/wompi/wompi.service.ts
+++ b/Back/payment-onboarding-backend/src/modules/wompi/wompi.service.ts
@@ -132,4 +132,29 @@ export class WompiService {
       );
     }
   }
+
+  async getTransactionStatus(transactionId: string): Promise<any> {
+    const headers = {
+      Authorization: `Bearer ${this.privateKey}`,
+      'Content-Type': 'application/json',
+    };
+  
+    try {
+      const response = await firstValueFrom(
+        this.httpService.get(`${this.apiUrl}/transactions/${transactionId}`, {
+          headers,
+        }),
+      );
+      return response.data;
+    } catch (error) {
+      console.error('❌ Error consultando estado de la transacción:');
+      console.error('Status:', error.response?.status);
+      console.error('Data:', error.response?.data);
+      throw new HttpException({
+        message: 'Error consultando el estado de la transacción',
+        wompiError: error.response?.data || null,
+      }, error.response?.status || 500);
+    }
+  }  
 }
+


### PR DESCRIPTION
### ✅ Cambios incluidos

Este Pull Request agrega un nuevo endpoint en el backend para consultar el estado de una transacción específica en Wompi, usando su ID.

### 🔧 ¿Qué incluye?

- Nuevo método en el `WompiController` con la ruta: `GET /wompi/transaction-status/:id`
- Llamado desde el servicio a la API pública de Wompi con el ID recibido
- Manejo de errores si el ID no existe
- Logging del resultado en consola para depuración

### 🧪 Cómo probarlo

1. Realiza una transacción exitosa.
2. Copia el `transaction_id` de la respuesta.
3. Haz una petición `GET` a:

